### PR TITLE
modified:   src/api/embedHandler.js, changed uploadsRegex

### DIFF
--- a/src/api/embedHandler.js
+++ b/src/api/embedHandler.js
@@ -14,7 +14,7 @@ let log = require("../utils/logger");
 let config = require("../utils/configHandler").getConfig();
 
 const regexes = {
-    uploadsRegex: /http(?:s?):\/\/pr0gramm\.com\/(?:top|new)(?:(?:\/.+)?)\/(\d+)/gi,
+		uploadsRegex: /http(?:s?):\/\/pr0gramm\.com\/(?:(?:top|new)|(?:user\/\w+\/uploads))\/(\d+)/gi,
     commentRegex: /http(?:s?):\/\/pr0gramm\.com\/(?:top|new)(?:(?:\/.+)?)\/(\d+)(?::)comment(\d+)/gi,
     userInfRegex: /http(?:s?):\/\/pr0gramm\.com\/user\/(\w+)/gi
 };


### PR DESCRIPTION
Links in the form of 'https://pr0gramm.com/user/username/uploads/1234567' have not been
matched by the uploadsRegex, instead they were matched by the
userInfRegex and the bot posted an user information embed.
Changed the uploadsRegex so it would match these links aswell.